### PR TITLE
fix: tableview container insets

### DIFF
--- a/Sources/Core/UIKit/UITableView/Calculators/DynamicHeightCalculator.swift
+++ b/Sources/Core/UIKit/UITableView/Calculators/DynamicHeightCalculator.swift
@@ -29,8 +29,9 @@ open class DynamicHeightCalculator: BaseTableViewHeightCalculator {
     
         let bounds = tableView.bounds.size
         let parameters = Size.ContainerProperties(containerBounds: bounds,
-                                                        maximumWidth: bounds.width,
-                                                         maximumHeight: nil)
+                                                  containerInsets: tableView.adjustedContentInset,
+                                                  maximumWidth: bounds.width,
+                                                  maximumHeight: nil)
         guard let height = elementSize.size(for: parameters)?.height else {
             return autoHeightForItem(at: indexPath, in: tableView, type: type)
         }


### PR DESCRIPTION
While using the `Size.container(useContentInsets: true)` in a `ViewModel` inside a UITableView, the `useContentInsets` parameter is not taken in consideration. 
As a result, for the full-screen elements like an empty state, the height of the element is greater than the visible area, causing it to scroll.

This pull request fix the issue but feel free to reject it and to take a look yourself.

Thanks