### PR TITLE
Let the user specify the insert/reload/delete animations

### DIFF
--- a/Sources/Rx/TableView+Rx.swift
+++ b/Sources/Rx/TableView+Rx.swift
@@ -35,15 +35,19 @@ public extension Reactive where Base: UITableView {
     }
 
     func animated(by viewModel: RxListViewModel,
-                  dataSource tableViewDataSource: TableViewDataSource) -> Disposable {
+                  dataSource tableViewDataSource: TableViewDataSource,
+                  insertAnimation: UITableView.RowAnimation = .automatic,
+                  reloadAnimation: UITableView.RowAnimation = .automatic,
+                  deleteAnimation: UITableView.RowAnimation = .automatic) -> Disposable {
 
-        let data = RxTableViewSectionedAnimatedDataSource<AnimatableSectionModel<Section, UniqueViewModelWrapper>> { (_, tableView, indexPath, _) -> UITableViewCell in
+        let data = RxTableViewSectionedAnimatedDataSource<AnimatableSectionModel<Section, UniqueViewModelWrapper>>(animationConfiguration: .init(insertAnimation: insertAnimation, reloadAnimation: reloadAnimation, deleteAnimation: deleteAnimation),
+                                                                                                                   configureCell: { (_, tableView, indexPath, _) -> UITableViewCell in
             tableViewDataSource.tableView(tableView, cellForRowAt: indexPath)
-        } canEditRowAtIndexPath: { (_, indexPath) -> Bool in
+        }, canEditRowAtIndexPath: { (_, indexPath) -> Bool in
             tableViewDataSource.tableView(base, canEditRowAt: indexPath)
-        } canMoveRowAtIndexPath: { (_, indexPath) -> Bool in
+        }, canMoveRowAtIndexPath: { (_, indexPath) -> Bool in
             tableViewDataSource.tableView(base, canMoveRowAt: indexPath)
-        }
+        })
        
         return viewModel.sectionsRelay
             .asDriver()


### PR DESCRIPTION
The RxDataSource's animations options for the UITableView are set to automatic.
Sometimes it causes some automatic animation selection that is not so great to see.
It would be nice for the users to specify the kind of animations they want while using the UITableView.

In some project i wrote an extension to choose the animation but it would be nice if Boomerang integrates it itself.
Feel free to reject it if you think is not useful :)

Thank you
